### PR TITLE
EXP:deletion_capacity – expose synthetic drift parameters

### DIFF
--- a/code/data_loader/linear.py
+++ b/code/data_loader/linear.py
@@ -197,7 +197,12 @@ def get_synthetic_linear_stream(
     fix_w_norm: bool = True,
     # Estimation diagnostics
     strong_convexity_estimation: bool = True,
+    G_hat: Optional[float] = None,
+    D_hat: Optional[float] = None,
+    c_hat: Optional[float] = None,
+    C_hat: Optional[float] = None,
 ):
+
     """Generate an infinite linear regression stream with configurable covariance.
 
     Parameters
@@ -264,7 +269,13 @@ def get_synthetic_linear_stream(
 
     # Always emit event records; legacy tuple mode removed
     return _generate_linear_stream_with_schema(
-        cov_gen, path_controller, sc_estimator, noise_std, rng
+        cov_gen, path_controller, sc_estimator, noise_std, rng,
+        rotate_angle=rotate_angle,
+        drift_rate=drift_rate,
+        G_hat=G_hat,
+        D_hat=D_hat,
+        c_hat=c_hat,
+        C_hat=C_hat,
     )
 
 
@@ -274,6 +285,12 @@ def _generate_linear_stream_with_schema(
     sc_estimator: Optional[StrongConvexityEstimator],
     noise_std: float,
     rng: np.random.Generator,
+    rotate_angle: Optional[float] = None,
+    drift_rate: Optional[float] = None,
+    G_hat: Optional[float] = None,
+    D_hat: Optional[float] = None,
+    c_hat: Optional[float] = None,
+    C_hat: Optional[float] = None,
 ) -> Iterator[Dict[str, Any]]:
     """Generate infinite linear stream with event schema and diagnostics.
 
@@ -331,6 +348,12 @@ def _generate_linear_stream_with_schema(
                 "x_norm": x_norm,
                 "w_star_norm": w_star_norm,
                 "noise": noise_draw,
+                "rotate_angle": rotate_angle,
+                "drift_rate": drift_rate,
+                "G_hat": G_hat,
+                "D_hat": D_hat,
+                "c_hat": c_hat,
+                "C_hat": C_hat,
             },
             lambda_est=float(lambda_est) if lambda_est is not None else None,
             P_T_true=float(P_T_true) if P_T_true is not None else None,

--- a/experiments/deletion_capacity/config.py
+++ b/experiments/deletion_capacity/config.py
@@ -90,6 +90,14 @@ class Config:
     drift_window: int = 10  # Duration of LR boost in steps
     drift_adaptation: bool = False  # Enable drift-responsive learning rate
 
+    # Synthetic stream drift parameters
+    rotate_angle: float = 0.01
+    drift_rate: float = 0.001
+    G_hat: Optional[float] = None
+    D_hat: Optional[float] = None
+    c_hat: Optional[float] = None
+    C_hat: Optional[float] = None
+
     @property
     def gamma_insert(self) -> float:
         """Gamma budget allocated to insertions (learning)."""

--- a/experiments/deletion_capacity/grids.yaml
+++ b/experiments/deletion_capacity/grids.yaml
@@ -6,6 +6,12 @@ matrix:
   gamma_bar: [1.0]
   gamma_split: [0.3, 0.5, 0.7]
   delete_ratio: [3, 5]
+  rotate_angle: [0.01]
+  drift_rate: [0.001]
+  G_hat: [null]
+  D_hat: [null]
+  c_hat: [null]
+  C_hat: [null]
 
   # Oracle block (optional)
   enable_oracle: [true, false]

--- a/experiments/deletion_capacity/runner.py
+++ b/experiments/deletion_capacity/runner.py
@@ -31,7 +31,16 @@ def _get_data_stream(cfg: Config, seed: int):
     stream_fn = DATASET_MAP[cfg.dataset]
     # Always request event records; legacy tuple mode removed
     if cfg.dataset == "synthetic":
-        return stream_fn(seed=seed, use_event_schema=True)
+        return stream_fn(
+            seed=seed,
+            use_event_schema=True,
+            rotate_angle=cfg.rotate_angle,
+            drift_rate=cfg.drift_rate,
+            G_hat=cfg.G_hat,
+            D_hat=cfg.D_hat,
+            c_hat=cfg.c_hat,
+            C_hat=cfg.C_hat,
+        )
     else:
         return stream_fn(seed=seed, use_event_schema=True)
 

--- a/experiments/deletion_capacity/tests/test_stream_params.py
+++ b/experiments/deletion_capacity/tests/test_stream_params.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Smoke test to ensure synthetic stream parameters propagate from Config to events."""
+
+import os
+import sys
+
+# Add paths for imports
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+REPO_ROOT = os.path.dirname(BASE_DIR)
+sys.path.append(BASE_DIR)
+sys.path.append(os.path.join(REPO_ROOT, 'code'))
+
+from config import Config
+from runner import _get_data_stream
+from data_loader import parse_event_record
+
+def main():
+    cfg = Config(
+        dataset="synthetic",
+        seeds=1,
+        rotate_angle=0.2,
+        drift_rate=0.05,
+        G_hat=3.0,
+        D_hat=1.5,
+        c_hat=0.2,
+        C_hat=4.0,
+    )
+    gen = _get_data_stream(cfg, seed=0)
+    record = next(gen)
+    _, _, meta = parse_event_record(record)
+    metrics = meta["metrics"]
+
+    assert metrics["rotate_angle"] == 0.2
+    assert metrics["drift_rate"] == 0.05
+    assert metrics["G_hat"] == 3.0
+    assert metrics["D_hat"] == 1.5
+    assert metrics["c_hat"] == 0.2
+    assert metrics["C_hat"] == 4.0
+
+    print("Stream parameters propagated correctly.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add optional drift and calibration parameters to deletion-capacity config and grid
- forward new parameters through runner to synthetic linear stream generator
- update linear stream generator to surface drift and calibration constants in event metrics
- add regression test ensuring stream parameters propagate from config to events

## Testing
- `/usr/bin/python3 code/data_loader/sanity_check.py --dataset rotmnist`
- `/usr/bin/python3 experiments/deletion_capacity/cli.py --help`
- `/usr/bin/python3 experiments/deletion_capacity/tests/test_stream_params.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7391b330c8331abf55f1c7225ae00